### PR TITLE
Create missing ~/.cache/python-bugzilla/ directory

### DIFF
--- a/src/Bugzilla.hs
+++ b/src/Bugzilla.hs
@@ -132,7 +132,7 @@ bzLoginSession = do
     getBzLoginSession :: BugzillaContext -> UserEmail -> IO BugzillaSession
     getBzLoginSession ctx user = do
       cache <- getUserCacheFile "python-bugzilla" "bugzillatoken"
-      let (cacheDir, _) = splitFileName cache
+      let cacheDir = takeDirectory cache
       cacheDirExists <- doesDirectoryExist cacheDir
       unless cacheDirExists $ createDirectory cacheDir
       fileExists <- doesFileExist cache

--- a/src/Bugzilla.hs
+++ b/src/Bugzilla.hs
@@ -53,6 +53,7 @@ import Control.Exception (finally)
 import qualified Data.ByteString.Char8 as B
 import Data.Ini.Config
 import Network.HTTP.Simple
+import System.Directory (doesDirectoryExist, createDirectory)
 import System.Environment
 import System.Environment.XDG.BaseDir
 import System.IO (hSetEcho, stdin)
@@ -131,6 +132,9 @@ bzLoginSession = do
     getBzLoginSession :: BugzillaContext -> UserEmail -> IO BugzillaSession
     getBzLoginSession ctx user = do
       cache <- getUserCacheFile "python-bugzilla" "bugzillatoken"
+      let (cacheDir, _) = splitFileName cache
+      cacheDirExists <- doesDirectoryExist cacheDir
+      unless cacheDirExists $ createDirectory cacheDir
       fileExists <- doesFileExist cache
       tokenstatus <- if fileExists
         then do


### PR DESCRIPTION
This change ensures the ~/.cache/python-bugzilla directory exists to prevent this
failure:
  fbrnch: ~/.cache/python-bugzilla/bugzillatoken: openFile: does not exist