### PR TITLE
bugzilla: ensure ini file is correct

### DIFF
--- a/src/Bugzilla.hs
+++ b/src/Bugzilla.hs
@@ -149,7 +149,7 @@ bzLoginSession = do
           return $ LoginSession ctx $ BugzillaToken token
         NoToken -> do
           token <- bzLogin
-          T.writeFile cache $ "[" <> brc <> "]\ntoken = " <> token
+          T.writeFile cache $ "[" <> brc <> "]\ntoken = " <> token <> "\n"
           putStrLn $ "Saved in " ++ cache
           return $ LoginSession ctx $ BugzillaToken token
       where


### PR DESCRIPTION
This change prevents such issue:
  fbrnch: ini file:2:26:
    |
  2 | token = XXXXXXX-XXXXXXXXXX
    |                          ^
  unexpected end of input
  expecting end of line